### PR TITLE
transrate_folllower/folloing_form_userPanel

### DIFF
--- a/app/views/partial/_userPanel.html.haml
+++ b/app/views/partial/_userPanel.html.haml
@@ -16,10 +16,7 @@
         .btn-right
           = render "partial/follow_form" , {user: user}
         %h8.card-text.text-secondary #{user.username}
-        %p.card-text
-          = truncate(user.about, length:40)
         .body-bottom.d-md-inline-flex
           %a.text-muted.card-link{href: "#"} ツイート：#{current_user.tweets.count}
-          %a.text-muted.card-link{href: "#"} フォロー：#{current_user.following.count}
-          %a.text-muted.card-link{href: "#"} フォロワー：#{current_user.followers.count}
-
+          = link_to "フォロー#{current_user.following.count}", "/users/#{current_user.id}/following" ,class: 'text-muted card-link'
+          = link_to "フォロワー#{current_user.followers.count}", "/users/#{current_user.id}/followers" ,class: 'text-muted card-link'


### PR DESCRIPTION
#WHAT
ユーザーパネルからフォロワーとフォローを一覧ページに遷移
ユーザーパネルのaboutは不要なため削除

#WHY
利便性向上
