### PR TITLE
add_autocomplete_off

### DIFF
--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,24 +5,20 @@
   .signupMain
     = form_for(resource, as: resource_name, url: registration_path(resource_name) ,html: { class: 'signupMain__form' })do |f|
       = devise_error_messages!
-      / %form.signupMain__form
       %p.signupMain__form__instraction アカウントを作成
       .cp_iptxt
         .ef
-          = f.text_field :name, placeholder: "名前"
+          = f.text_field :name, placeholder: "名前" ,autocomplete: "off"
       .cp_iptxt
         .ef
-          = f.text_field :username, placeholder: "@ユーザーネーム"
+          = f.text_field :username, placeholder: "@ユーザーネーム",autocomplete: "off"
       .cp_iptxt
         .ef
-          = f.email_field :email, placeholder: "メールアドレス"
+          = f.email_field :email, placeholder: "メールアドレス",autocomplete: "off"
       .cp_iptxt
         .ef
-          = f.password_field :password, placeholder: "パスワード"
-
+          = f.password_field :password, placeholder: "パスワード",autocomplete: "off"
       .signupMain__form__policy アカウントを作成すると、利用規約、およびCookieの使用を含むプライバシーポリシーに同意したことになります。あなたのメールアドレスや電話番号を連絡先に保存しているTwitterユーザーに通知などが表示されます。プライバシーの設定
-
       .signupMain__form__btn
         = f.submit "登録する", type: "submit", class: "signupMain__form__submits"
 
-/ = render "devise/shared/links"


### PR DESCRIPTION
#WHAT
ユーザー登録にキャッシュを残さないようにした
#WHY
新規登録時の関係のない情報が表示されてしまっていたため